### PR TITLE
Print Route 53 Hosted zone Web URL

### DIFF
--- a/aws_utils/print.go
+++ b/aws_utils/print.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/jedib0t/go-pretty/v6/table"
 	log "github.com/sirupsen/logrus"
 )
@@ -84,8 +85,13 @@ func (r *GetRecordAliasesResult) printHostedzoneTable(opts *PrintOptions) {
 
 	t := table.NewWriter()
 
+	hzIdDisplay := aws.StringValue(r.HostedZone.Id)
+	r53Url := GenerateRoute53HostedZoneWebURL(hzIdDisplay)
+	if r53Url != "" {
+		hzIdDisplay = fmt.Sprintf("%s\n\n%s\n", hzIdDisplay, r53Url)
+	}
 	t.AppendHeader(table.Row{"Hosted Zone", "Id", "Total records", "Private"}, rowConfigAutoMerge)
-	t.AppendRow(table.Row{*r.HostedZone.Name, *r.HostedZone.Id, *r.HostedZone.ResourceRecordSetCount, *r.HostedZone.Config.PrivateZone}, rowConfigAutoMerge)
+	t.AppendRow(table.Row{*r.HostedZone.Name, hzIdDisplay, *r.HostedZone.ResourceRecordSetCount, *r.HostedZone.Config.PrivateZone}, rowConfigAutoMerge)
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
 		{Number: 2, AutoMerge: true},

--- a/aws_utils/urls.go
+++ b/aws_utils/urls.go
@@ -53,6 +53,19 @@ func CheckRoutableAWSTarget(r *route53.ResourceRecordSet) (string, bool) {
 	return "", false
 }
 
+// id is typicall /hostedzone/1234LZW9ITZ26T and we need only 1234LZW9ITZ26T
+func GenerateRoute53HostedZoneWebURL(hzId string) string {
+	splittedId := strings.Split(hzId, "/")
+
+	if len(splittedId) < 1 {
+		return ""
+	}
+
+	id := splittedId[len(splittedId)-1]
+	r53Url := fmt.Sprintf("https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/%s", id)
+	return r53Url
+}
+
 func GenerateWebURL(r *route53.ResourceRecordSet) (string, error) {
 	e := errors.New("ErrNotRoutable")
 	if dnsType, routable := CheckRoutableAWSTarget(r); routable {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+Copyright © 2020 Isan Rivkin isanrivkin@gmail.com
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	AppVersion = "0.3.1"
+	AppVersion = "0.3.2"
 )
 
 var cfgFile string

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+Copyright © 2020 Isan Rivkin isanrivkin@gmail.com
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Until now the tool printed the web URL to the resources R53 is pointing to (i.e Load Balancer Console). 

Now, it outputs Web URL to the Hosted Zone itself as well:

`https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/$hostedzone`